### PR TITLE
Issue #41 - Config option to make Civilians safe

### DIFF
--- a/src/net/sacredlabyrinth/phaed/simpleclans/listeners/SCEntityListener.java
+++ b/src/net/sacredlabyrinth/phaed/simpleclans/listeners/SCEntityListener.java
@@ -198,6 +198,25 @@ public class SCEntityListener extends EntityListener
                         return;
                     }
                 }
+                else
+                {
+                    // not part of a clan - check if safeCivilians is set
+                    if (plugin.getSettingsManager().getSafeCivilians())
+                    {
+                        event.setCancelled(true);
+                        return;
+                    }
+                }
+            }
+            else
+            {
+                // not part of a clan - check if safeCivilians is set
+                if (plugin.getSettingsManager().getSafeCivilians())
+                {
+                    event.setCancelled(true);
+                    return;
+                }
+
             }
         }
     }

--- a/src/net/sacredlabyrinth/phaed/simpleclans/managers/CommandManager.java
+++ b/src/net/sacredlabyrinth/phaed/simpleclans/managers/CommandManager.java
@@ -47,7 +47,7 @@ public final class CommandManager
     private ReloadCommand reloadCommand;
     private GlobalffCommand globalffCommand;
     private MenuCommand menuCommand;
-    private WarCommand warCommand;
+    //private WarCommand warCommand;
 
     /**
      *
@@ -87,7 +87,7 @@ public final class CommandManager
         unbanCommand = new UnbanCommand();
         reloadCommand = new ReloadCommand();
         globalffCommand = new GlobalffCommand();
-        warCommand = new WarCommand();
+        //warCommand = new WarCommand();
     }
 
     /**
@@ -242,10 +242,10 @@ public final class CommandManager
                 {
                     globalffCommand.execute(player, subargs);
                 }
-                else if (subcommand.equalsIgnoreCase(plugin.getLang().getString("war.command")))
+               /** else if (subcommand.equalsIgnoreCase(plugin.getLang().getString("war.command")))
                 {
                     warCommand.execute(player, subargs);
-                }
+                } **/
                 else
                 {
                     ChatBlock.sendMessage(player, ChatColor.RED + plugin.getLang().getString("does.not.match"));
@@ -592,8 +592,8 @@ public final class CommandManager
         return menuCommand;
     }
 
-    public WarCommand getWarCommand()
+    /**public WarCommand getWarCommand()
     {
         return warCommand;
-    }
+    }**/
 }

--- a/src/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
+++ b/src/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
@@ -87,6 +87,7 @@ public final class SettingsManager
     private String database;
     private String username;
     private String password;
+    private boolean safeCivilians;
 
     /**
      *
@@ -188,6 +189,7 @@ public final class SettingsManager
         database = config.getString("mysql.database", "");
         username = config.getString("mysql.username", "");
         password = config.getString("mysql.password", "");
+        safeCivilians = config.getBoolean("safe-civilians", false);
         save();
     }
 
@@ -267,7 +269,7 @@ public final class SettingsManager
         config.setProperty("mysql.database", database);
         config.setProperty("mysql.username", username);
         config.setProperty("mysql.password", password);
-
+        config.setProperty("safe-civilians", safeCivilians);
         config.save();
     }
 
@@ -979,4 +981,11 @@ public final class SettingsManager
     {
         return bbShowOnLogin;
     }
+
+    public boolean getSafeCivilians()
+    {
+        return safeCivilians;
+    }
+
+
 }


### PR DESCRIPTION
Added safe-civilians config option - civilians can't be attacked in PvP (default: false)
Removed command hooks for WarCommand - WarCommand.java not in github

Compiled and running on my test server
