### PR TITLE
Why would you leave debug data like this in a published build? That glas...

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/TeleportManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/TeleportManager.java
@@ -131,11 +131,6 @@ public final class TeleportManager
                                 int x = loc.getBlockX();
                                 int z = loc.getBlockZ();
 
-                                player.sendBlockChange(new Location(loc.getWorld(), x + 1, loc.getBlockY() - 1, z + 1), Material.GLASS, (byte) 0);
-                                player.sendBlockChange(new Location(loc.getWorld(), x - 1, loc.getBlockY() - 1, z - 1), Material.GLASS, (byte) 0);
-                                player.sendBlockChange(new Location(loc.getWorld(), x + 1, loc.getBlockY() - 1, z - 1), Material.GLASS, (byte) 0);
-                                player.sendBlockChange(new Location(loc.getWorld(), x - 1, loc.getBlockY() - 1, z + 1), Material.GLASS, (byte) 0);
-
                                 if (!plugin.getPermissionsManager().has(player, "simpleclans.mod.keep-items"))
                                 {
                                     dropItems(player);


### PR DESCRIPTION
...s does not go away on its own, and you do not clear it up.
