### PR TITLE
Fix ever-increasing whitespace in packed strings

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -920,7 +920,7 @@ public class Clan implements Serializable, Comparable<Clan>
      */
     public void setPackedBb(String packedBb)
     {
-        this.bb = new ArrayList<String>(Helper.fromArray(packedBb.split("[|]")));
+        this.bb = new ArrayList<String>(Helper.fromArray(packedBb.split("\\s*(\\||$)")));
     }
 
     /**
@@ -940,7 +940,7 @@ public class Clan implements Serializable, Comparable<Clan>
      */
     public void setPackedAllies(String packedAllies)
     {
-        this.allies = new HashSet<String>(Helper.fromArray(packedAllies.split("[|]")));
+        this.allies = new HashSet<String>(Helper.fromArray(packedAllies.split("\\s*(\\||$)")));
     }
 
     /**
@@ -960,7 +960,7 @@ public class Clan implements Serializable, Comparable<Clan>
      */
     public void setPackedRivals(String packedRivals)
     {
-        this.rivals = new HashSet<String>(Helper.fromArray(packedRivals.split("[|]")));
+        this.rivals = new HashSet<String>(Helper.fromArray(packedRivals.split("\\s*(\\||$)")));
     }
 
     /**


### PR DESCRIPTION
Clan allies, rivals and BB are not loading properly because the whitespace added by Helper.toMessage(String[] args, String sep) is not being removed by Helper.fromArray.
This regex change fixes this by removing all traling whitespace before the separator.
