### PR TITLE
Fix clanff not accepting any arguments.

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/ClanffCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/ClanffCommand.java
@@ -22,7 +22,7 @@ public class ClanffCommand extends GenericPlayerCommand
     {
         super("Clanff");
         this.plugin = plugin;
-        setArgumentRange(0, 0);
+        setArgumentRange(1, 1);
         setUsages(MessageFormat.format(plugin.getLang("usage.clanff"), plugin.getSettingsManager().getCommandClan()));
         setIdentifiers(plugin.getLang("clanff.command"));
     }


### PR DESCRIPTION
@p000ison
`/clan clanff` does not work because it is set to receive at most zero arguments.
