### PR TITLE
Update Mysql source code for language support

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/storage/MySQLCore.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/storage/MySQLCore.java
@@ -41,7 +41,7 @@ public class MySQLCore implements DBCore {
         try
         {
             Class.forName("com.mysql.jdbc.Driver");
-            connection = DriverManager.getConnection("jdbc:mysql://" + host + "/" + database, username, password);
+            connection = DriverManager.getConnection("jdbc:mysql://" + host + "/" + database, username, password + "?useUnicode=true&characterEncoding=utf-8");
         }
         catch (ClassNotFoundException e)
         {


### PR DESCRIPTION
seems if used Japanese string to clantag, it will be full ?.

I added line that force use utf-8 for DB connection.

(P.S. I am japanese. So Sorry for bad english)