### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/CommandHelper.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/CommandHelper.java
@@ -12,6 +12,9 @@ import java.util.Arrays;
 
 public class CommandHelper
 {
+	
+	private CommandHelper() {}
+	
     public static void registerCommand(String... aliases)
     {
         if (aliases != null)

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Dates.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Dates.java
@@ -11,6 +11,9 @@ import java.util.Date;
 
 public class Dates
 {
+	
+	private Dates() {}
+	
     /**
      *
      * @param date1

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Helper.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Helper.java
@@ -19,6 +19,8 @@ import java.util.*;
  */
 public class Helper
 {
+	
+	private Helper() {}
 
     /**
      * Dumps stacktrace to log

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/StringSimplifier.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/StringSimplifier.java
@@ -7,6 +7,9 @@ import java.util.regex.Pattern;
 
 public class StringSimplifier
 {
+	
+	private StringSimplifier() {}
+	
     public static final char DEFAULT_REPLACE_CHAR = '-';
     public static final String DEFAULT_REPLACE = String.valueOf(DEFAULT_REPLACE_CHAR);
     private static final ImmutableMap<String, String> NONDIACRITICS = ImmutableMap.<String, String>builder()

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/uuid/UUIDMigration.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/uuid/UUIDMigration.java
@@ -13,6 +13,8 @@ import org.bukkit.entity.Player;
  */
 public class UUIDMigration {
 
+	private UUIDMigration() {}
+	
     public static boolean canReturnUUID() {
         if(!SimpleClans.getInstance().getSettingsManager().isOnlineMode())
             return false;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed