### PR TITLE
Code quality fix - Classes and methods that rely on the default system encoding should not be used. 

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/SimpleClans.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/SimpleClans.java
@@ -5,6 +5,7 @@ import net.sacredlabyrinth.phaed.simpleclans.listeners.SCEntityListener;
 import net.sacredlabyrinth.phaed.simpleclans.listeners.SCPlayerListener;
 import net.sacredlabyrinth.phaed.simpleclans.managers.*;
 import net.sacredlabyrinth.phaed.simpleclans.uuid.UUIDMigration;
+
 import org.bukkit.ChatColor;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -12,6 +13,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.PropertyResourceBundle;
@@ -134,7 +136,8 @@ public class SimpleClans extends JavaPlugin {
 
         try
         {
-            BufferedReader in = new BufferedReader(new InputStreamReader(new URL("https://minecraftcubed.net/pluginmessage/").openStream()));
+            BufferedReader in = new BufferedReader(new InputStreamReader(new URL("https://minecraftcubed.net/pluginmessage/").openStream()
+            		, StandardCharsets.UTF_8));
 
             String message;
             while ((message = in.readLine()) != null)

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/uuid/UUIDFetcher.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/uuid/UUIDFetcher.java
@@ -1,6 +1,7 @@
 package net.sacredlabyrinth.phaed.simpleclans.uuid;
 
 import com.google.common.collect.ImmutableList;
+
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -10,6 +11,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.Callable;
 
@@ -39,7 +41,7 @@ public class UUIDFetcher implements Callable<Map<String, UUID>> {
 
     private static void writeBody(HttpURLConnection connection, String body) throws Exception {
         OutputStream stream = connection.getOutputStream();
-        stream.write(body.getBytes());
+        stream.write(body.getBytes(StandardCharsets.UTF_8));
         stream.flush();
         stream.close();
     }
@@ -92,7 +94,7 @@ public class UUIDFetcher implements Callable<Map<String, UUID>> {
             HttpURLConnection connection = createConnection();
             String body = JSONArray.toJSONString(names.subList(i * 100, Math.min((i + 1) * 100, names.size())));
             writeBody(connection, body);
-            JSONArray array = (JSONArray) jsonParser.parse(new InputStreamReader(connection.getInputStream()));
+            JSONArray array = (JSONArray) jsonParser.parse(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
             for (Object profile : array) {
                 JSONObject jsonProfile = (JSONObject) profile;
                 String id = (String) jsonProfile.get("id");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1943 - Classes and methods that rely on the default system encoding should not be used. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1943
 
Please let me know if you have any questions.

Faisal Hameed