### PR TITLE
Code quality fix - Useless parentheses around expressions should be removed to prevent any misunderstanding.

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/ChatBlock.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/ChatBlock.java
@@ -792,10 +792,10 @@ public class ChatBlock
      */
     public static String colorize(String message)
     {
-        return colorizeBase((new String[]
+        return colorizeBase(new String[]
                 {
                     message
-                }))[0];
+                })[0];
     }
 
     /**

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/ClanPlayer.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/ClanPlayer.java
@@ -466,7 +466,7 @@ public class ClanPlayer implements Serializable, Comparable<ClanPlayer>
     public double getWeightedKills()
     {
         SimpleClans plugin = SimpleClans.getInstance();
-        return (((double) rivalKills * plugin.getSettingsManager().getKwRival()) + ((double) neutralKills * plugin.getSettingsManager().getKwNeutral()) + ((double) civilianKills * plugin.getSettingsManager().getKwCivilian()));
+        return ((double) rivalKills * plugin.getSettingsManager().getKwRival()) + ((double) neutralKills * plugin.getSettingsManager().getKwNeutral()) + ((double) civilianKills * plugin.getSettingsManager().getKwCivilian());
     }
 
     /**

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Helper.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Helper.java
@@ -690,7 +690,7 @@ public class Helper
             }
             else
             {
-                return ((Collection<Player>) players);
+                return (Collection<Player>) players;
             }
         }
         catch (Exception e)

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/CoordsCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/CoordsCommand.java
@@ -63,7 +63,7 @@ public class CoordsCommand
 
                                 if (p != null)
                                 {
-                                    String name = (cpm.isLeader() ? plugin.getSettingsManager().getPageLeaderColor() : ((cpm.isTrusted() ? plugin.getSettingsManager().getPageTrustedColor() : plugin.getSettingsManager().getPageUnTrustedColor()))) + cpm.getName();
+                                    String name = (cpm.isLeader() ? plugin.getSettingsManager().getPageLeaderColor() : (cpm.isTrusted() ? plugin.getSettingsManager().getPageTrustedColor() : plugin.getSettingsManager().getPageUnTrustedColor())) + cpm.getName();
                                     Location loc = p.getLocation();
                                     int distance = (int) Math.ceil(loc.toVector().distance(player.getLocation().toVector()));
                                     String coords = loc.getBlockX() + " " + loc.getBlockY() + " " + loc.getBlockZ();

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/LeaderboardCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/LeaderboardCommand.java
@@ -66,8 +66,8 @@ public class LeaderboardCommand
                     }
 
 
-                    String name = (cp.isLeader() ? plugin.getSettingsManager().getPageLeaderColor() : ((cp.isTrusted() ? plugin.getSettingsManager().getPageTrustedColor() : plugin.getSettingsManager().getPageUnTrustedColor()))) + cp.getName();
-                    String lastSeen = (isOnline ? ChatColor.GREEN + plugin.getLang("online") : ChatColor.WHITE + cp.getLastSeenDaysString());
+                    String name = (cp.isLeader() ? plugin.getSettingsManager().getPageLeaderColor() : (cp.isTrusted() ? plugin.getSettingsManager().getPageTrustedColor() : plugin.getSettingsManager().getPageUnTrustedColor())) + cp.getName();
+                    String lastSeen = isOnline ? ChatColor.GREEN + plugin.getLang("online") : ChatColor.WHITE + cp.getLastSeenDaysString();
 
                     String clanTag = ChatColor.WHITE + plugin.getLang("free.agent");
 

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/RosterCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/RosterCommand.java
@@ -94,7 +94,7 @@ public class RosterCommand
                     Player p = cp.toPlayer();
 
                     String name = plugin.getSettingsManager().getPageLeaderColor() + cp.getName();
-                    String lastSeen = (p != null && p.isOnline() && !Helper.isVanished(p) ? ChatColor.GREEN + plugin.getLang("online") : ChatColor.WHITE + cp.getLastSeenDaysString());
+                    String lastSeen = p != null && p.isOnline() && !Helper.isVanished(p) ? ChatColor.GREEN + plugin.getLang("online") : ChatColor.WHITE + cp.getLastSeenDaysString();
 
                     chatBlock.addRow("  " + name, ChatColor.YELLOW + Helper.parseColors(cp.getRank()), lastSeen);
 
@@ -105,7 +105,7 @@ public class RosterCommand
                     Player p = cp.toPlayer();
 
                     String name = (cp.isTrusted() ? plugin.getSettingsManager().getPageTrustedColor() : plugin.getSettingsManager().getPageUnTrustedColor()) + cp.getName();
-                    String lastSeen = (p != null && p.isOnline() && !Helper.isVanished(p) ? ChatColor.GREEN + plugin.getLang("online") : ChatColor.WHITE + cp.getLastSeenDaysString());
+                    String lastSeen = p != null && p.isOnline() && !Helper.isVanished(p) ? ChatColor.GREEN + plugin.getLang("online") : ChatColor.WHITE + cp.getLastSeenDaysString();
 
                     chatBlock.addRow("  " + name, ChatColor.YELLOW + Helper.parseColors(cp.getRank()), lastSeen);
                 }

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/StatsCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/StatsCommand.java
@@ -67,7 +67,7 @@ public class StatsCommand
 
                             for (ClanPlayer cpm : leaders)
                             {
-                                String name = (cpm.isLeader() ? plugin.getSettingsManager().getPageLeaderColor() : ((cpm.isTrusted() ? plugin.getSettingsManager().getPageTrustedColor() : plugin.getSettingsManager().getPageUnTrustedColor()))) + cpm.getName();
+                                String name = (cpm.isLeader() ? plugin.getSettingsManager().getPageLeaderColor() : (cpm.isTrusted() ? plugin.getSettingsManager().getPageTrustedColor() : plugin.getSettingsManager().getPageUnTrustedColor())) + cpm.getName();
                                 String rival = NumberFormat.getInstance().format(cpm.getRivalKills());
                                 String neutral = NumberFormat.getInstance().format(cpm.getNeutralKills());
                                 String civilian = NumberFormat.getInstance().format(cpm.getCivilianKills());
@@ -79,7 +79,7 @@ public class StatsCommand
 
                             for (ClanPlayer cpm : members)
                             {
-                                String name = (cpm.isLeader() ? plugin.getSettingsManager().getPageLeaderColor() : ((cpm.isTrusted() ? plugin.getSettingsManager().getPageTrustedColor() : plugin.getSettingsManager().getPageUnTrustedColor()))) + cpm.getName();
+                                String name = (cpm.isLeader() ? plugin.getSettingsManager().getPageLeaderColor() : (cpm.isTrusted() ? plugin.getSettingsManager().getPageTrustedColor() : plugin.getSettingsManager().getPageUnTrustedColor())) + cpm.getName();
                                 String rival = NumberFormat.getInstance().format(cpm.getRivalKills());
                                 String neutral = NumberFormat.getInstance().format(cpm.getNeutralKills());
                                 String civilian = NumberFormat.getInstance().format(cpm.getCivilianKills());

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/VitalsCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/VitalsCommand.java
@@ -66,7 +66,7 @@ public class VitalsCommand
 
                                 if (p != null)
                                 {
-                                    String name = (cpm.isLeader() ? plugin.getSettingsManager().getPageLeaderColor() : ((cpm.isTrusted() ? plugin.getSettingsManager().getPageTrustedColor() : plugin.getSettingsManager().getPageUnTrustedColor()))) + cpm.getName();
+                                    String name = (cpm.isLeader() ? plugin.getSettingsManager().getPageLeaderColor() : (cpm.isTrusted() ? plugin.getSettingsManager().getPageTrustedColor() : plugin.getSettingsManager().getPageUnTrustedColor())) + cpm.getName();
                                     String health = plugin.getClanManager().getHealthString(p.getHealth());
                                     String hunger = plugin.getClanManager().getHungerString(p.getFoodLevel());
                                     String armor = plugin.getClanManager().getArmorString(p.getInventory());
@@ -87,7 +87,7 @@ public class VitalsCommand
 
                                 if (p != null)
                                 {
-                                    String name = (cpm.isLeader() ? plugin.getSettingsManager().getPageLeaderColor() : ((cpm.isTrusted() ? plugin.getSettingsManager().getPageTrustedColor() : plugin.getSettingsManager().getPageUnTrustedColor()))) + cpm.getName();
+                                    String name = (cpm.isLeader() ? plugin.getSettingsManager().getPageLeaderColor() : (cpm.isTrusted() ? plugin.getSettingsManager().getPageTrustedColor() : plugin.getSettingsManager().getPageUnTrustedColor())) + cpm.getName();
                                     String health = plugin.getClanManager().getHealthString(p.getHealth());
                                     String hunger = plugin.getClanManager().getHungerString(p.getFoodLevel());
                                     String armor = plugin.getClanManager().getArmorString(p.getInventory());

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/PermissionsManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/PermissionsManager.java
@@ -370,7 +370,7 @@ public final class PermissionsManager
         {
             permission = permissionProvider.getProvider();
         }
-        return (permission != null);
+        return permission != null;
     }
 
     private Boolean setupChat()
@@ -381,7 +381,7 @@ public final class PermissionsManager
             chat = chatProvider.getProvider();
         }
 
-        return (chat != null);
+        return chat != null;
     }
 
     private Boolean setupEconomy()
@@ -392,7 +392,7 @@ public final class PermissionsManager
             economy = economyProvider.getProvider();
         }
 
-        return (economy != null);
+        return economy != null;
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed