### PR TITLE
General code quality fix-1

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/KillsCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/KillsCommand.java
@@ -1,12 +1,14 @@
 package net.sacredlabyrinth.phaed.simpleclans.commands;
 
 import net.sacredlabyrinth.phaed.simpleclans.*;
+
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 public class KillsCommand
 {
@@ -63,11 +65,11 @@ public class KillsCommand
 
                          Map<String, Integer> killsPerPlayer = Helper.sortByValue(killsPerPlayerUnordered);
 
-                        for (String playerName : killsPerPlayer.keySet())
+                        for (Entry<String, Integer> playerKills : killsPerPlayer.entrySet())
                         {
-                            int count = killsPerPlayer.get(playerName);
+                            int count = playerKills.getValue();
 
-                            chatBlock.addRow("  " + playerName, ChatColor.AQUA + "" + count);
+                            chatBlock.addRow("  " + playerKills.getKey(), ChatColor.AQUA + "" + count);
                         }
 
                         ChatBlock.saySingle(player, plugin.getSettingsManager().getPageClanNameColor() + Helper.capitalize(polledPlayerName) + subColor + " " + plugin.getLang("kills") + " " + headColor + Helper.generatePageSeparator(plugin.getSettingsManager().getPageSep()));

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/MostKilledCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/MostKilledCommand.java
@@ -1,12 +1,14 @@
 package net.sacredlabyrinth.phaed.simpleclans.commands;
 
 import net.sacredlabyrinth.phaed.simpleclans.*;
+
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 public class MostKilledCommand
 {
@@ -56,16 +58,16 @@ public class MostKilledCommand
 
                         Map<String, Integer> killsPerPlayer = Helper.sortByValue(killsPerPlayerUnordered);
 
-                        for (String attackerVictim : killsPerPlayer.keySet())
+                        for (Entry<String, Integer> attackerVictim : killsPerPlayer.entrySet())
                         {
-                            String[] split = attackerVictim.split(" ");
+                            String[] split = attackerVictim.getKey().split(" ");
 
                             if (split.length < 2)
                             {
                                 continue;
                             }
 
-                            int count = killsPerPlayer.get(attackerVictim);
+                            int count = attackerVictim.getValue();
                             String attacker = split[0];
                             String victim = split[1];
 

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/PermissionsManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/PermissionsManager.java
@@ -23,9 +23,9 @@ public final class PermissionsManager
      */
     private SimpleClans plugin;
 
-    public static Permission permission = null;
-    public static Economy economy = null;
-    public static Chat chat = null;
+    private static Permission permission = null;
+    private static Economy economy = null;
+    private static Chat chat = null;
 
     private HashMap<String, List<String>> permissions = new HashMap<String, List<String>>();
     private HashMap<Player, PermissionAttachment> permAttaches = new HashMap<Player, PermissionAttachment>();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck

Please let me know if you have any questions.

Faisal Hameed