### PR TITLE
Actually prevent a player without permission from using /clan reload

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/ReloadCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/ReloadCommand.java
@@ -28,7 +28,8 @@ public class ReloadCommand
 
         if (sender instanceof Player && !plugin.getPermissionsManager().has((Player)sender, "simpleclans.admin.reload"))
         {
-        	ChatBlock.sendMessage(sender, ChatColor.RED + "Think you're slick don't ya");
+        	ChatBlock.sendMessage(sender, ChatColor.RED + "Does not match a clan command");
+        	return;
         }
 
         plugin.getSettingsManager().load();


### PR DESCRIPTION
Also changed the message sent when no permissions are given.

Or can be changed to "insufficient permission" idc, unless there's a language constant I can use instead (and would prefer to use).