### PR TITLE
Lower chat event priority slightly

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/listeners/SCPlayerListener.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/listeners/SCPlayerListener.java
@@ -168,7 +168,7 @@ public class SCPlayerListener implements Listener
     /**
      * @param event
      */
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGH)
     public void onPlayerChat(AsyncPlayerChatEvent event)
     {
         if (plugin.getSettingsManager().isBlacklistedWorld(event.getPlayer().getLocation().getWorld().getName()))


### PR DESCRIPTION
This allows plugins that may be monitoring chat on highest priority to test whether a message has been canceled by SimpleClans or not while still keeping the priority high enough that things such as chat filtering plugins can cancel chat events for players in clan or ally chats.