### PR TITLE
Fix VerifyCommand permission check

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/VerifyCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/VerifyCommand.java
@@ -41,7 +41,7 @@ public class VerifyCommand {
                     clan.addBb(player.getName(), ChatColor.AQUA + MessageFormat.format(plugin.getLang("clan.0.has.been.verified"), clan.getName()));
                     ChatBlock.sendMessage(player, ChatColor.AQUA + plugin.getLang("the.clan.has.been.verified"));
                 }
-            } else if (plugin.getPermissionsManager().has(player, "simpleclans.mod.verify")) {
+            } else if (!plugin.getPermissionsManager().has(player, "simpleclans.mod.verify")) {
                 if (arg.length != 1) {
                     ChatBlock.sendMessage(player, ChatColor.RED + plugin.getLang("insufficient.permissions"));
                     return;


### PR DESCRIPTION
Fixes a small typo which only grants access to the command if you don't have the permission