### PR TITLE
make globalff executable from console

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/GlobalffCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/GlobalffCommand.java
@@ -3,6 +3,7 @@ package net.sacredlabyrinth.phaed.simpleclans.commands;
 import net.sacredlabyrinth.phaed.simpleclans.ChatBlock;
 import net.sacredlabyrinth.phaed.simpleclans.SimpleClans;
 import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import java.text.MessageFormat;
@@ -20,7 +21,7 @@ public class GlobalffCommand {
      * @param player
      * @param arg
      */
-    public void execute(Player player, String[] arg) {
+    public void execute(CommandSender player, String[] arg) {
         SimpleClans plugin = SimpleClans.getInstance();
 
         if (arg.length != 1) {

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/executors/ClanCommandExecutor.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/executors/ClanCommandExecutor.java
@@ -221,7 +221,10 @@ public final class ClanCommandExecutor implements CommandExecutor {
                         reloadCommand.execute(sender, subargs);
                     } else if (subcommand.equalsIgnoreCase(plugin.getLang("place.command"))) {
                         placeCommand.execute(sender, subargs);
-                    } else {
+                    } else if (subcommand.equalsIgnoreCase(plugin.getLang("globalff.command"))) {
+                        globalffCommand.execute(sender, subargs);
+                    }
+                    else {
                         ChatBlock.sendMessage(sender, ChatColor.RED + plugin.getLang("does.not.match"));
                     }
                 }


### PR DESCRIPTION
So I found out why my stuff was returning null and such, it's because when doing the refactor from sender to player, I also happened to refactor all the strings that used "player" to access a given string from the file (e.g. lookup command, s.player.info was refactored to s.sender.info, which does not exist and was the cause of the null exception).

Anyways, this is the only command I really wanted to execute from console anyways, so I'll just PR this for now, and PR others, one at a time (I guess) later if needed.
