### PR TITLE
Bulletin Board: Timestamp and limit size on login

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: java
 
 script: mvn install
 
-jdk: [openjdk7]
+jdk: [openjdk8]
 
 # if one build failed, exit testing
 matrix:

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <fork>true</fork>
@@ -58,6 +58,12 @@
     </build>
     <!-- Dependencies -->
     <dependencies>
+        <dependency>
+            <groupId>com.destroystokyo.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.12.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
@@ -100,6 +106,10 @@
         <repository>
             <id>remote-repos</id>
             <url>http://104.236.246.108:8081/artifactory/remote-repos</url>
+        </repository>
+        <repository>
+            <id>paper-repo</id>
+            <url>https://repo.destroystokyo.com/repository/maven-public/</url>
         </repository>
     </repositories>
 

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/ChatBlock.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/ChatBlock.java
@@ -637,63 +637,6 @@ public class ChatBlock {
     }
 
     /**
-     * Returns the string representation of the amount of time passed
-     * @author RoboMWM, LaxWasHere
-     * @param seconds the time, in the past
-     * @param depth
-     * @return
-     */
-    public static String formatTime(Long seconds, int depth)
-    {
-        if (seconds == null || seconds < 1) {
-            return "moments";
-        }
-
-        if (seconds < 60) {
-            return seconds + " seconds";
-        }
-
-        if (seconds < 3600) {
-            Long count = (long) Math.ceil(seconds / 60);
-            String res;
-            if (count > 1) {
-                res = count + " minutes";
-            } else {
-                res = "1 minute";
-            }
-            Long remaining = seconds % 60;
-            if (depth > 0 && remaining >= 5) {
-                return res + ", " + formatTime(remaining, --depth);
-            }
-            return res;
-        }
-        if (seconds < 86400) {
-            Long count = (long) Math.ceil(seconds / 3600);
-            String res;
-            if (count > 1) {
-                res = count + " hours";
-            } else {
-                res = "1 hour";
-            }
-            if (depth > 0) {
-                return res + ", " + formatTime(seconds % 3600, --depth);
-            }
-            return res;
-        }
-        Long count = (long) Math.ceil(seconds / 86400);
-        String res;
-        if (count > 1) {
-            res = count + " days";
-        } else {
-            res = "1 day";
-        }
-        if (depth > 0) {
-            return res + ", " + formatTime(seconds % 86400, --depth);
-        }
-        return res;
-    }
-
-    /**
      * Colors each line
      *
      * @param message

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/ChatBlock.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/ChatBlock.java
@@ -610,6 +610,10 @@ public class ChatBlock {
         }
     }
 
+    public static String[] getColorizedMessage(String msg) {
+        return colorize(wordWrap(msg));
+    }
+
     /**
      * Send blank lie
      *
@@ -630,6 +634,63 @@ public class ChatBlock {
         }
 
         receiver.sendMessage(" ");
+    }
+
+    /**
+     * Returns the string representation of the amount of time passed
+     * @author RoboMWM, LaxWasHere
+     * @param seconds the time, in the past
+     * @param depth
+     * @return
+     */
+    public static String formatTime(Long seconds, int depth)
+    {
+        if (seconds == null || seconds < 1) {
+            return "moments";
+        }
+
+        if (seconds < 60) {
+            return seconds + " seconds";
+        }
+
+        if (seconds < 3600) {
+            Long count = (long) Math.ceil(seconds / 60);
+            String res;
+            if (count > 1) {
+                res = count + " minutes";
+            } else {
+                res = "1 minute";
+            }
+            Long remaining = seconds % 60;
+            if (depth > 0 && remaining >= 5) {
+                return res + ", " + formatTime(remaining, --depth);
+            }
+            return res;
+        }
+        if (seconds < 86400) {
+            Long count = (long) Math.ceil(seconds / 3600);
+            String res;
+            if (count > 1) {
+                res = count + " hours";
+            } else {
+                res = "1 hour";
+            }
+            if (depth > 0) {
+                return res + ", " + formatTime(seconds % 3600, --depth);
+            }
+            return res;
+        }
+        Long count = (long) Math.ceil(seconds / 86400);
+        String res;
+        if (count > 1) {
+            res = count + " days";
+        } else {
+            res = "1 day";
+        }
+        if (depth > 0) {
+            return res + ", " + formatTime(seconds % 86400, --depth);
+        }
+        return res;
     }
 
     /**

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -1551,7 +1551,7 @@ public class Clan implements Serializable, Comparable<Clan> {
             if (index < 1)
                 return false;
             long time;
-            time = (System.currentTimeMillis() - Long.parseLong(msg.substring(0, index)) / 1000L);
+            time = (System.currentTimeMillis() - Long.parseLong(msg.substring(0, index))) / 1000L;
             msg = String.join("", ChatBlock.getColorizedMessage(SimpleClans.getInstance().getSettingsManager().getBbAccentColor() + "* " + SimpleClans.getInstance().getSettingsManager().getBbColor() + Helper.parseColors(msg.substring(++index, msg.length()))));
             TextComponent textComponent = new TextComponent(msg);
             textComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(Dates.formatTime(time, 1) + " ago ")));

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -1528,7 +1528,7 @@ public class Clan implements Serializable, Comparable<Clan> {
 
             List<String> localBb = new ArrayList<>(bb);
             while (localBb.size() > maxSize) {
-                bb.remove(0);
+                localBb.remove(0);
             }
 
             for (String msg : bb) {

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -1515,6 +1515,32 @@ public class Clan implements Serializable, Comparable<Clan> {
     }
 
     /**
+     * Displays bb to a player
+     * @implNote may want to refactor displaybb(Player) to use this?
+     *
+     * @param player
+     * @param maxSize amount of lines to display
+     */
+    public void displayBb(Player player, int maxSize) {
+        if (isVerified()) {
+            ChatBlock.sendBlank(player);
+            ChatBlock.saySingle(player, MessageFormat.format(SimpleClans.getInstance().getLang("bulletin.board.header"), SimpleClans.getInstance().getSettingsManager().getBbAccentColor(), SimpleClans.getInstance().getSettingsManager().getPageHeadingsColor(), Helper.capitalize(getName())));
+
+            List<String> localBb = new ArrayList<>(bb);
+            while (localBb.size() > maxSize) {
+                bb.remove(0);
+            }
+
+            for (String msg : bb) {
+                if (!sendBbTime(player, msg)) {
+                    ChatBlock.sendMessage(player, SimpleClans.getInstance().getSettingsManager().getBbAccentColor() + "* " + SimpleClans.getInstance().getSettingsManager().getBbColor() + Helper.parseColors(msg));
+                }
+            }
+            ChatBlock.sendBlank(player);
+        }
+    }
+
+    /**
      * Sends a bb message with the timestamp in a hover message, if the bb message is timestamped
      * @param msg the bb message
      * @return true if sent

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -1,5 +1,7 @@
 package net.sacredlabyrinth.phaed.simpleclans;
 
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
 import net.sacredlabyrinth.phaed.simpleclans.uuid.UUIDMigration;
 import net.sacredlabyrinth.phaed.simpleclans.events.*;
 import org.bukkit.ChatColor;
@@ -373,7 +375,7 @@ public class Clan implements Serializable, Comparable<Clan> {
             bb.remove(0);
         }
 
-        bb.add(msg);
+        bb.add(System.currentTimeMillis() + "_" + msg);
         SimpleClans.getInstance().getStorageManager().updateClan(this);
     }
     
@@ -389,7 +391,7 @@ public class Clan implements Serializable, Comparable<Clan> {
             bb.remove(0);
         }
 
-        bb.add(msg);
+        bb.add(System.currentTimeMillis() + "_" + msg);
         SimpleClans.getInstance().getStorageManager().updateClan(this, updateLastUsed);
     }
 
@@ -1504,9 +1506,34 @@ public class Clan implements Serializable, Comparable<Clan> {
             }
 
             for (String msg : bb) {
-                ChatBlock.sendMessage(player, SimpleClans.getInstance().getSettingsManager().getBbAccentColor() + "* " + SimpleClans.getInstance().getSettingsManager().getBbColor() + Helper.parseColors(msg));
+                if (!sendBbTime(player, msg)) {
+                    ChatBlock.sendMessage(player, SimpleClans.getInstance().getSettingsManager().getBbAccentColor() + "* " + SimpleClans.getInstance().getSettingsManager().getBbColor() + Helper.parseColors(msg));
+                }
             }
             ChatBlock.sendBlank(player);
+        }
+    }
+
+    /**
+     * Sends a bb message with the timestamp in a hover message, if the bb message is timestamped
+     * @param msg the bb message
+     * @return true if sent
+     */
+    private boolean sendBbTime(Player player, String msg) {
+        try {
+            int index = msg.indexOf("_");
+            if (index < 1)
+                return false;
+            long time;
+            time = Long.parseLong(msg.substring(index));
+            msg = String.join("", ChatBlock.getColorizedMessage(SimpleClans.getInstance().getSettingsManager().getBbAccentColor() + "* " + SimpleClans.getInstance().getSettingsManager().getBbColor() + Helper.parseColors(msg.substring(++index, msg.length()))));
+            TextComponent textComponent = new TextComponent(msg);
+            textComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(ChatBlock.formatTime(time, 1))));
+            player.sendMessage(textComponent);
+            return true;
+        }
+        catch (Throwable rock) {
+            return false;
         }
     }
 

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -1551,7 +1551,7 @@ public class Clan implements Serializable, Comparable<Clan> {
             if (index < 1)
                 return false;
             long time;
-            time = System.currentTimeMillis() - Long.parseLong(msg.substring(0, index));
+            time = (System.currentTimeMillis() - Long.parseLong(msg.substring(0, index)) / 1000L);
             msg = String.join("", ChatBlock.getColorizedMessage(SimpleClans.getInstance().getSettingsManager().getBbAccentColor() + "* " + SimpleClans.getInstance().getSettingsManager().getBbColor() + Helper.parseColors(msg.substring(++index, msg.length()))));
             TextComponent textComponent = new TextComponent(msg);
             textComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(Dates.formatTime(time, 1) + " ago ")));

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -1551,7 +1551,7 @@ public class Clan implements Serializable, Comparable<Clan> {
             if (index < 1)
                 return false;
             long time;
-            time = Long.parseLong(msg.substring(index));
+            time = Long.parseLong(msg.substring(0, index));
             msg = String.join("", ChatBlock.getColorizedMessage(SimpleClans.getInstance().getSettingsManager().getBbAccentColor() + "* " + SimpleClans.getInstance().getSettingsManager().getBbColor() + Helper.parseColors(msg.substring(++index, msg.length()))));
             TextComponent textComponent = new TextComponent(msg);
             textComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(ChatBlock.formatTime(time, 1))));

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -1531,7 +1531,7 @@ public class Clan implements Serializable, Comparable<Clan> {
                 localBb.remove(0);
             }
 
-            for (String msg : bb) {
+            for (String msg : localBb) {
                 if (!sendBbTime(player, msg)) {
                     ChatBlock.sendMessage(player, SimpleClans.getInstance().getSettingsManager().getBbAccentColor() + "* " + SimpleClans.getInstance().getSettingsManager().getBbColor() + Helper.parseColors(msg));
                 }

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -1551,10 +1551,10 @@ public class Clan implements Serializable, Comparable<Clan> {
             if (index < 1)
                 return false;
             long time;
-            time = Long.parseLong(msg.substring(0, index));
+            time = System.currentTimeMillis() - Long.parseLong(msg.substring(0, index));
             msg = String.join("", ChatBlock.getColorizedMessage(SimpleClans.getInstance().getSettingsManager().getBbAccentColor() + "* " + SimpleClans.getInstance().getSettingsManager().getBbColor() + Helper.parseColors(msg.substring(++index, msg.length()))));
             TextComponent textComponent = new TextComponent(msg);
-            textComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(ChatBlock.formatTime(time, 1))));
+            textComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(Dates.formatTime(time, 1) + " ago ")));
             player.sendMessage(textComponent);
             return true;
         }

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Dates.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Dates.java
@@ -135,4 +135,61 @@ public class Dates {
         cal.setTime(date);
         return cal.getTimeInMillis() + cal.getTimeZone().getOffset(cal.getTimeInMillis());
     }
+
+    /**
+     * Returns the string representation of the amount of time labeled as days, hours, minutes, seconds
+     * @author RoboMWM, LaxWasHere
+     * @param seconds the time, in the past
+     * @param depth Max amount of detail (e.g. only display days and hours if set to 1 and seconds > 1 day)
+     * @return
+     */
+    public static String formatTime(Long seconds, int depth)
+    {
+        if (seconds == null || seconds < 1) {
+            return "moments";
+        }
+
+        if (seconds < 60) {
+            return seconds + " seconds";
+        }
+
+        if (seconds < 3600) {
+            Long count = (long) Math.ceil(seconds / 60);
+            String res;
+            if (count > 1) {
+                res = count + " minutes";
+            } else {
+                res = "1 minute";
+            }
+            Long remaining = seconds % 60;
+            if (depth > 0 && remaining >= 5) {
+                return res + ", " + formatTime(remaining, --depth);
+            }
+            return res;
+        }
+        if (seconds < 86400) {
+            Long count = (long) Math.ceil(seconds / 3600);
+            String res;
+            if (count > 1) {
+                res = count + " hours";
+            } else {
+                res = "1 hour";
+            }
+            if (depth > 0) {
+                return res + ", " + formatTime(seconds % 3600, --depth);
+            }
+            return res;
+        }
+        Long count = (long) Math.ceil(seconds / 86400);
+        String res;
+        if (count > 1) {
+            res = count + " days";
+        } else {
+            res = "1 day";
+        }
+        if (depth > 0) {
+            return res + ", " + formatTime(seconds % 86400, --depth);
+        }
+        return res;
+    }
 }

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Dates.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Dates.java
@@ -139,7 +139,7 @@ public class Dates {
     /**
      * Returns the string representation of the amount of time labeled as days, hours, minutes, seconds
      * @author RoboMWM, LaxWasHere
-     * @param seconds the time, in the past
+     * @param seconds the time in seconds
      * @param depth Max amount of detail (e.g. only display days and hours if set to 1 and seconds > 1 day)
      * @return
      */

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/listeners/SCPlayerListener.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/listeners/SCPlayerListener.java
@@ -238,7 +238,7 @@ public class SCPlayerListener implements Listener {
         SimpleClans.getInstance().getPermissionsManager().addPlayerPermissions(cp);
 
         if (plugin.getSettingsManager().isBbShowOnLogin() && cp.isBbEnabled()) {
-            cp.getClan().displayBb(player, plugin.getSettingsManager().getBbJoinSize());
+            cp.getClan().displayBb(player, plugin.getSettingsManager().getBbLoginSize());
         }
 
         SimpleClans.getInstance().getPermissionsManager().addClanPermissions(cp);

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/listeners/SCPlayerListener.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/listeners/SCPlayerListener.java
@@ -238,7 +238,7 @@ public class SCPlayerListener implements Listener {
         SimpleClans.getInstance().getPermissionsManager().addPlayerPermissions(cp);
 
         if (plugin.getSettingsManager().isBbShowOnLogin() && cp.isBbEnabled()) {
-            cp.getClan().displayBb(player);
+            cp.getClan().displayBb(player, plugin.getSettingsManager().getBbJoinSize());
         }
 
         SimpleClans.getInstance().getPermissionsManager().addClanPermissions(cp);

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
@@ -73,6 +73,7 @@ public final class SettingsManager {
     private String pageUnTrustedColor;
     private boolean bbShowOnLogin;
     private int bbSize;
+    private int bbJoinSize;
     private String bbColor;
     private String bbAccentColor;
     private String commandClan;
@@ -239,6 +240,7 @@ public final class SettingsManager {
         pageClanNameColor = getConfig().getString("page.clan-name-color");
         bbShowOnLogin = getConfig().getBoolean("bb.show-on-login");
         bbSize = getConfig().getInt("bb.size");
+        bbJoinSize = getConfig().getInt("bb.join-size", bbSize);
         bbColor = getConfig().getString("bb.color");
         bbAccentColor = getConfig().getString("bb.accent-color");
         commandClan = getConfig().getString("commands.clan");
@@ -677,6 +679,13 @@ public final class SettingsManager {
      */
     public int getBbSize() {
         return bbSize;
+    }
+
+    /**
+     * @return the bbJoinSize
+     */
+    public int getBbJoinSize() {
+        return bbJoinSize;
     }
 
     /**

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
@@ -73,7 +73,7 @@ public final class SettingsManager {
     private String pageUnTrustedColor;
     private boolean bbShowOnLogin;
     private int bbSize;
-    private int bbJoinSize;
+    private int bbLoginSize;
     private String bbColor;
     private String bbAccentColor;
     private String commandClan;
@@ -240,7 +240,7 @@ public final class SettingsManager {
         pageClanNameColor = getConfig().getString("page.clan-name-color");
         bbShowOnLogin = getConfig().getBoolean("bb.show-on-login");
         bbSize = getConfig().getInt("bb.size");
-        bbJoinSize = getConfig().getInt("bb.join-size", bbSize);
+        bbLoginSize = getConfig().getInt("bb.login-size", bbSize);
         bbColor = getConfig().getString("bb.color");
         bbAccentColor = getConfig().getString("bb.accent-color");
         commandClan = getConfig().getString("commands.clan");
@@ -682,10 +682,10 @@ public final class SettingsManager {
     }
 
     /**
-     * @return the bbJoinSize
+     * @return the bbLoginSize
      */
-    public int getBbJoinSize() {
-        return bbJoinSize;
+    public int getBbLoginSize() {
+        return bbLoginSize;
     }
 
     /**


### PR DESCRIPTION
### Timestamped bulletin board messages
- All bulletin board messages added from this version on will be internally timestamped.
- Old bulletin board messages will continue to work as per usual
- Timestamp is displayed using a hoverable TextComponent.
  - The Paper API was added to support this (since we're only using spigot APIs, this is also compatible with spigot)
  - Falls back to standard way of printing bb messages if no timestamp can be found or a TextComponent can't be created (i.e. using CB)

You may want to refactor some of the methods I added if you wish to do so (e.g. Clan#displayBb). I've kept the original methods mostly as-is to mitigate merge conflicts in case this is not pulled.

### Bulletin board size on login
- The config key `bb.login-size` is used, and defaults to the value in `size` if not set.

I have not added this key to the default config.yml

If you're interested in pulling this, I'll be happy to refactor and add the config node, unless if you want to do that.