### PR TITLE
Deny calculating kills with the same IP to stop gaining unfair kills and KDR.

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/listeners/SCEntityListener.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/listeners/SCEntityListener.java
@@ -15,6 +15,7 @@ import org.bukkit.event.entity.EntityTargetLivingEntityEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 
 import java.text.MessageFormat;
+import java.util.logging.Level;
 
 /**
  * @author phaed
@@ -78,6 +79,18 @@ public class SCEntityListener implements Listener
 
             if (attacker != null && victim != null)
             {
+            	if (SimpleClans.getInstance().getSettingsManager().isDenySameIPKills()) 
+            	{
+            		if (attacker.getAddress().getHostString().equals(victim.getAddress().getHostString())) 
+            		{
+            			plugin.getLogger().log(Level.INFO, "Blocked same IP kill calculating: {0} killed {1}. IP: {2}", new Object[]{
+                                    attacker.getDisplayName(), victim.getDisplayName(), attacker.getAddress().getHostString()
+                                });
+            			return;
+            			
+            		}
+            	}
+            	            
                 ClanPlayer acp;
                 ClanPlayer vcp;
                 if (SimpleClans.getInstance().hasUUID())

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
@@ -143,6 +143,7 @@ public final class SettingsManager {
     private boolean homebaseSetOnce;
     private int waitSecs;
     private boolean enableAutoGroups;
+    private boolean denySameIPKills;
     private boolean moneyperkill;
     private double KDRMultipliesPerKill;
     private boolean teleportBlocks;
@@ -300,6 +301,7 @@ public final class SettingsManager {
         kwRival = getConfig().getDouble("kill-weights.rival");
         kwNeutral = getConfig().getDouble("kill-weights.neutral");
         kwCivilian = getConfig().getDouble("kill-weights.civilian");
+        denySameIPKills = getConfig().getBoolean("kill-weights.deny-same-ip-kills");
         useMysql = getConfig().getBoolean("mysql.enable");
         host = getConfig().getString("mysql.host");
         port = getConfig().getInt("mysql.port");
@@ -1067,6 +1069,10 @@ public final class SettingsManager {
 
     public boolean isConfirmationForDemote() {
         return confirmationForDemote;
+    }
+
+    public boolean isDenySameIPKills() {
+        return denySameIPKills;
     }
 
     public boolean isUseColorCodeFromPrefix() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -77,6 +77,7 @@ kill-weights:
     rival: 2.0
     civilian: 0.0
     neutral: 1.0
+    deny-same-ip-kills: false
 clan:
     homebase-teleport-wait-secs: 10
     homebase-can-be-set-only-once: true


### PR DESCRIPTION
If some player is killed by another one, check both attacker and victim IP addresses.
If they are the same don't calculate that kill and send the message to the server console.
The check can be turned on by setting `kill-weights.deny-same-ip-kills` to `true` in `config.yml`.