### PR TITLE
Fix bypassing /clan home regroup

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/HomeCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/HomeCommand.java
@@ -165,9 +165,11 @@ public class HomeCommand {
 
             if (!cp.isLeader()) {
                 ChatBlock.sendMessage(player, ChatColor.RED + plugin.getLang("no.leader.permissions"));
+                return;
             }
             if (!plugin.getPermissionsManager().has(player, "simpleclans.leader.home-regroup")) {
                 ChatBlock.sendMessage(player, ChatColor.RED + plugin.getLang("insufficient.permissions"));
+                return;
             }
 
             HomeRegroupEvent homeRegroupEvent = new HomeRegroupEvent(clan, cp, clan.getOnlineMembers(), loc);


### PR DESCRIPTION
Clan members can use /clan home regroup without being leaders and also without having the permission simpleclans.leader.home-regroup

Just added a return statement to both conditionals.

Let me show you a screenshot of the bypass: https://imgur.com/a/dCrM6uZ (Im getting the no leader message, and the no permission message, but im going home anyways)

Thanks!