### PR TITLE
/clan home command fixes

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/HomeCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/HomeCommand.java
@@ -171,6 +171,11 @@ public class HomeCommand {
                 ChatBlock.sendMessage(player, ChatColor.RED + plugin.getLang("insufficient.permissions"));
                 return;
             }
+            
+            if (loc == null) {
+                ChatBlock.sendMessage(player, ChatColor.RED + plugin.getLang("hombase.not.set"));
+                return;
+            }
 
             HomeRegroupEvent homeRegroupEvent = new HomeRegroupEvent(clan, cp, clan.getOnlineMembers(), loc);
             SimpleClans.getInstance().getServer().getPluginManager().callEvent(homeRegroupEvent);

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/HomeCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/HomeCommand.java
@@ -207,7 +207,6 @@ public class HomeCommand {
                 
                 plugin.getTeleportManager().addPlayer(player, new Location(loc.getWorld(), x + .5, loc.getBlockY(), z + .5), clan.getName());
             }
-            ChatBlock.sendMessage(player, ChatColor.AQUA + plugin.getLang("hombase.set") + ChatColor.YELLOW + Helper.toLocationString(loc));
             return;
         }
 


### PR DESCRIPTION
- Fixes this error when there is no home set for the clan (I just copied and pasted the loc == null statement): https://pastebin.com/jiXneTvK

Also can you please fix this placeholder? I dont want to touch anything there as maybe it breaks some stuff or it meant to be something: https://imgur.com/a/KWPDTk7
It says: "Clan home-base set to: {0}" + Location. I guess the 0 meant to be the location? Maybe adding a replace would fix it, unless the idea was to make something else.

Thanks for the awesome plugin and sorry for making another merge for the same, I just noticed it! 

Also another idea, what if instead of saying Insufficient Permission when you write a command wrongly it sends a usage message? For example, if I type /clan home tp, I get a no permission message, if I write /clan home tp test, then I go to the home of test clan. 

Thanks!