### PR TITLE
Check if AllyChat is disabled

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/listeners/SCPlayerListener.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/listeners/SCPlayerListener.java
@@ -106,7 +106,7 @@ public class SCPlayerListener implements Listener {
         }
 
         if (plugin.getSettingsManager().isForceCommandPriority()) {
-            if (command.equalsIgnoreCase(plugin.getSettingsManager().getCommandAlly())) {
+            if (command.equalsIgnoreCase(plugin.getSettingsManager().getCommandAlly()) && plugin.getSettingsManager().isAllyChatEnable()) {
                 if (!plugin.getServer().getPluginCommand(plugin.getSettingsManager().getCommandAlly()).equals(plugin.getCommand(plugin.getSettingsManager().getCommandAlly()))) {
                     new AllyCommandExecutor().onCommand(player, null, null, Helper.removeFirst(split));
                     event.setCancelled(true);


### PR DESCRIPTION
Added back the option to disable the "ally", if the command is disabled but ForceCommandPriority is enabled you can have this message erro: https://prnt.sc/t0kvv1